### PR TITLE
fix: interface JikanResourcePeriod

### DIFF
--- a/src/models/Common/resource.model.ts
+++ b/src/models/Common/resource.model.ts
@@ -19,7 +19,7 @@ export interface JikanResourcePeriod {
   from: string;
   to: string;
   prop: {
-    form: { day: number; month: number; year: number };
+    from: { day: number; month: number; year: number };
     to: { day: number; month: number; year: number };
     string: string;
   };


### PR DESCRIPTION
The JikanResourcePeriod interface has a small spelling error: 

f**or**m

https://github.com/tutkli/jikan-ts/blob/2f0d5b7531b63fd966d28d3ba98635ad46a3623e/src/models/Common/resource.model.ts#L18-L26

Reference: [Jikan](https://docs.api.jikan.moe/#tag/anime/operation/getAnimeById)
![grafik](https://github.com/tutkli/jikan-ts/assets/116148234/f2331d95-ae1a-4593-b0f0-5f92356cb08e)
