### PR TITLE
Cache issues on JikanClient Axios instance

### DIFF
--- a/src/clients/jikan.client.ts
+++ b/src/clients/jikan.client.ts
@@ -1,5 +1,5 @@
+import { AxiosInstance } from 'axios'
 import { AnimeClient } from './anime.client'
-import type { ClientArgs } from './base.client'
 import { CharactersClient } from './characters.client'
 import { GenresClient } from './genres.client'
 import { MangaClient } from './manga.client'
@@ -7,6 +7,34 @@ import { RandomClient } from './random.client'
 import { SchedulesClient } from './schedules.client'
 import { SeasonsClient } from './seasons.client'
 import { TopClient } from './top.client'
+import { CacheOptions } from 'axios-cache-interceptor'
+
+export interface JikanClientArgs {
+	/**
+	 * **EnableLogging**
+	 * Enables logging request responses.
+	 */
+	enableLogging: boolean
+
+	/**
+	 * **Axios Cache Options**
+	 * Options for cache.
+	 * @see https://axios-cache-interceptor.js.org/#/pages/configuration
+	 */
+	cacheOptions: Partial<CacheOptions>
+
+	/**
+	 * **Base URL**
+	 * Location of the JikanAPI. Leave empty to use the official JikanAPI instance.
+	 */
+	baseURL: string
+
+	/**
+	 * **Axios Instance Factory**
+	 * The ability to build your own axios instance if you need it
+	 */
+	axiosInstanceFactory?: () => AxiosInstance
+}
 
 /**
  * **Jikan Client**
@@ -25,14 +53,38 @@ export class JikanClient {
 	public seasons: SeasonsClient
 	public random: RandomClient
 
-	constructor(clientOptions?: Partial<ClientArgs>) {
-		this.anime = new AnimeClient(clientOptions)
-		this.characters = new CharactersClient(clientOptions)
-		this.genres = new GenresClient(clientOptions)
-		this.manga = new MangaClient(clientOptions)
-		this.top = new TopClient(clientOptions)
-		this.schedules = new SchedulesClient(clientOptions)
-		this.seasons = new SeasonsClient(clientOptions)
-		this.random = new RandomClient(clientOptions)
+	constructor(clientOptions?: Partial<JikanClientArgs>) {
+		this.anime = new AnimeClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
+		this.characters = new CharactersClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
+		this.genres = new GenresClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
+		this.manga = new MangaClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
+		this.top = new TopClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
+		this.schedules = new SchedulesClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
+		this.seasons = new SeasonsClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
+		this.random = new RandomClient({
+			...clientOptions,
+			axiosInstance: clientOptions?.axiosInstanceFactory?.()
+		})
 	}
 }


### PR DESCRIPTION
Hi,
using custom AxiosInstance, there is a problem with caching when it is passed down from JikanClient.

I got the intention from the code that for every client "anime/manga/...", a new AxiosInstance will be created by default. But when you specify your own from JikanClient, there is only one AxiosInstance for all the clients, and they will try to initialize the cache each time. This results in errors `setupcache() should be called only once`.

There are multiple ways to fix it. At first, I just replaced the AxiosInstance in the config with a factory for it, but this would break all current code. So, I made a copy of `clientOptions` for JikanClient separately which got a factory for the AxiosInstance. Probably nobody used JikanClient before with custom AxiosInstance? Should not break much, then.

Another way of fixing this is to do something with the caching mechanism.

Thanks.